### PR TITLE
Install missing custom plugins

### DIFF
--- a/set_up_shell.sh
+++ b/set_up_shell.sh
@@ -46,6 +46,14 @@ else
   echo "oh-my-zsh is already installed."
 fi
 
+# Install oh-my-zsh custom plugins
+if [ ! -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions" ]; then
+  git clone https://github.com/zsh-users/zsh-autosuggestions.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+fi
+if [ ! -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting" ]; then
+  git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+fi
+
 # Install powerline-shell font "Meslo Slashed"
 clone_or_update https://github.com/powerline/fonts.git --depth=1
 cd fonts


### PR DESCRIPTION
## Description

This PR fixes these issues upon initializing a shell session:

```sh
[oh-my-zsh] plugin 'zsh-autosuggestions' not found
[oh-my-zsh] plugin 'zsh-syntax-highlighting' not found
```

![CleanShot 2024-09-25 at 08 17 59@2x](https://github.com/user-attachments/assets/83cb6750-8a49-45e2-9d44-3f47e016beea)

And now we have sh syntax highlighting and autocomplete suggestions (that can be accepted by pressing the ⬆ key - not tab 🤗 )